### PR TITLE
fix: if_type_assert: compliance test passes

### DIFF
--- a/compliance/tests/if_type_assert/expected.log
+++ b/compliance/tests/if_type_assert/expected.log
@@ -1,0 +1,1 @@
+Expected: string

--- a/compliance/tests/if_type_assert/if_type_assert.go
+++ b/compliance/tests/if_type_assert/if_type_assert.go
@@ -3,7 +3,7 @@ package main
 func main() {
 	var a any
 	a = "this is a string"
-	if x, ok := a.(string); ok {
+	if _, ok := a.(string); ok {
 		println("Expected: string")
 	} else {
 		println("Not Expected: should be a string")

--- a/compliance/tests/if_type_assert/if_type_assert.gs.ts
+++ b/compliance/tests/if_type_assert/if_type_assert.gs.ts
@@ -1,0 +1,19 @@
+// Generated file based on if_type_assert.go
+// Updated when compliance tests are re-run, DO NOT EDIT!
+
+import * as $ from "@goscript/builtin/index.js";
+
+export async function main(): Promise<void> {
+	let a: null | any = null
+	a = "this is a string"
+	{
+		let { ok: ok } = $.typeAssert<string>(a, {kind: $.TypeKind.Basic, name: 'string'})
+		if (ok) {
+			console.log("Expected: string")
+		}
+		 else {
+			console.log("Not Expected: should be a string")
+		}
+	}
+}
+

--- a/compliance/tests/if_type_assert/tsconfig.json
+++ b/compliance/tests/if_type_assert/tsconfig.json
@@ -1,0 +1,30 @@
+{
+  "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "baseUrl": ".",
+    "lib": [
+      "es2022",
+      "esnext.disposable",
+      "dom"
+    ],
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "noEmit": true,
+    "paths": {
+      "@goscript/*": [
+        "../../../gs/*",
+        "../../../compliance/deps/*"
+      ],
+      "@goscript/github.com/aperturerobotics/goscript/compliance/tests/if_type_assert/*": [
+        "./*"
+      ]
+    },
+    "sourceMap": true,
+    "target": "es2022"
+  },
+  "extends": "../../../tsconfig.json",
+  "include": [
+    "if_type_assert.gs.ts",
+    "index.ts"
+  ]
+}


### PR DESCRIPTION
Fixes #92
Related to #91

cc @rcoreilly seems to have passed when I fixed this:

```
	if str, ok := a.(string); ok {
```

to

```
	if _, ok := a.(string); ok {
```

since `str` was unused.

there were some unrelated type checking errors below it in the error output previously.