### PR TITLE
fix(encoding/json): honor omitempty and unwrap boxed interface{} on marshal

### DIFF
--- a/gs/builtin/type.ts
+++ b/gs/builtin/type.ts
@@ -1685,6 +1685,23 @@ export function namedValueInterfaceValue<T>(
   return boxed as T
 }
 
+/**
+ * Reports whether a value is a boxed named-type interface value produced by
+ * namedValueInterfaceValue. Both markers are required: an ordinary JS object
+ * that merely happens to have a `__goValue` property (legal input elsewhere,
+ * e.g. through json.Marshal) is not a box.
+ */
+export function isNamedValueBox(
+  v: unknown,
+): v is { __goType: string; __goValue: unknown } {
+  return (
+    typeof v === 'object' &&
+    v !== null &&
+    '__goValue' in v &&
+    typeof (v as { __goType?: unknown }).__goType === 'string'
+  )
+}
+
 function wrapperMethodSignatureFromTypeInfo(
   name: string,
   typeInfo?: TypeInfo | string,

--- a/gs/encoding/json/index.test.ts
+++ b/gs/encoding/json/index.test.ts
@@ -85,6 +85,44 @@ class FieldAlias {
   )
 }
 
+class OmitEmptyStruct {
+  public _fields = {
+    Name: $.varRef(''),
+    Age: $.varRef(0),
+    Tags: $.varRef<string[]>([]),
+  }
+
+  static __typeInfo = $.registerStructType(
+    'test.OmitEmptyStruct',
+    new OmitEmptyStruct(),
+    [],
+    OmitEmptyStruct,
+    [
+      {
+        name: 'Name',
+        key: 'Name',
+        type: { kind: $.TypeKind.Basic, name: 'string' },
+        tag: 'json:"name,omitempty"',
+      },
+      {
+        name: 'Age',
+        key: 'Age',
+        type: { kind: $.TypeKind.Basic, name: 'int' },
+        tag: 'json:"age,omitempty"',
+      },
+      {
+        name: 'Tags',
+        key: 'Tags',
+        type: {
+          kind: $.TypeKind.Slice,
+          elemType: { kind: $.TypeKind.Basic, name: 'string' },
+        },
+        tag: 'json:"tags,omitempty"',
+      },
+    ],
+  )
+}
+
 describe('encoding/json override', () => {
   it('registers the Unmarshaler interface shape', () => {
     class CustomMarshaler implements Marshaler {
@@ -155,6 +193,42 @@ describe('encoding/json override', () => {
       Unmarshal($.stringToBytes('{"FullName":"Grace"}'), target),
     ).toBeNull()
     expect(target.value._fields.Name.value).toBe('Grace')
+  })
+
+  it('omits zero-valued fields tagged omitempty on marshal', () => {
+    const zero = new OmitEmptyStruct()
+    const [zeroData, zeroErr] = Marshal(zero)
+    expect(zeroErr).toBeNull()
+    expect($.bytesToString(zeroData)).toBe('{}')
+
+    const filled = new OmitEmptyStruct()
+    filled._fields.Name.value = 'Ada'
+    filled._fields.Age.value = 30
+    filled._fields.Tags.value = ['x']
+    const [data, err] = Marshal(filled)
+    expect(err).toBeNull()
+    expect($.bytesToString(data)).toBe('{"name":"Ada","age":30,"tags":["x"]}')
+  })
+
+  it('unwraps a boxed interface{} value before marshaling instead of leaking its wrapper', () => {
+    // A value of a named/defined type stored in an interface{} is boxed by
+    // the runtime as { __goType, __goValue, ... } so it can carry methods.
+    // Marshal must serialize the underlying value, not the wrapper.
+    const namedInt = $.namedValueInterfaceValue<unknown>(42, 'test.Status', {})
+    const [data, err] = Marshal(namedInt)
+    expect(err).toBeNull()
+    expect($.bytesToString(data)).toBe('42')
+
+    const namedString = $.namedValueInterfaceValue<unknown>(
+      'active',
+      'test.Status',
+      {},
+    )
+    const holder = new FieldAlias()
+    holder._fields.Name.value = namedString as unknown as string
+    const [holderData, holderErr] = Marshal(holder)
+    expect(holderErr).toBeNull()
+    expect($.bytesToString(holderData)).toBe('{"FullName":"active"}')
   })
 
   it('rejects unsupported values and invalid unmarshal targets', () => {

--- a/gs/encoding/json/index.test.ts
+++ b/gs/encoding/json/index.test.ts
@@ -90,6 +90,7 @@ class OmitEmptyStruct {
     Name: $.varRef(''),
     Age: $.varRef(0),
     Tags: $.varRef<string[]>([]),
+    Data: $.varRef<Uint8Array>(new Uint8Array(0)),
   }
 
   static __typeInfo = $.registerStructType(
@@ -118,6 +119,15 @@ class OmitEmptyStruct {
           elemType: { kind: $.TypeKind.Basic, name: 'string' },
         },
         tag: 'json:"tags,omitempty"',
+      },
+      {
+        name: 'Data',
+        key: 'Data',
+        type: {
+          kind: $.TypeKind.Slice,
+          elemType: { kind: $.TypeKind.Basic, name: 'uint8' },
+        },
+        tag: 'json:"data,omitempty"',
       },
     ],
   )
@@ -205,9 +215,12 @@ describe('encoding/json override', () => {
     filled._fields.Name.value = 'Ada'
     filled._fields.Age.value = 30
     filled._fields.Tags.value = ['x']
+    filled._fields.Data.value = $.stringToBytes('x')
     const [data, err] = Marshal(filled)
     expect(err).toBeNull()
-    expect($.bytesToString(data)).toBe('{"name":"Ada","age":30,"tags":["x"]}')
+    expect($.bytesToString(data)).toBe(
+      '{"name":"Ada","age":30,"tags":["x"],"data":"eA=="}',
+    )
   })
 
   it('unwraps a boxed interface{} value before marshaling instead of leaking its wrapper', () => {
@@ -225,7 +238,7 @@ describe('encoding/json override', () => {
       {},
     )
     const holder = new FieldAlias()
-    holder._fields.Name.value = namedString as unknown as string
+    ;(holder._fields.Name as $.VarRef<unknown>).value = namedString
     const [holderData, holderErr] = Marshal(holder)
     expect(holderErr).toBeNull()
     expect($.bytesToString(holderData)).toBe('{"FullName":"active"}')

--- a/gs/encoding/json/index.test.ts
+++ b/gs/encoding/json/index.test.ts
@@ -133,6 +133,44 @@ class OmitEmptyStruct {
   )
 }
 
+class OmitEmptyRefStruct {
+  public _fields = {
+    Ptr: $.varRef<unknown>(null),
+    Any: $.varRef<unknown>(null),
+    Count: $.varRef<bigint>(0n),
+  }
+
+  static __typeInfo = $.registerStructType(
+    'test.OmitEmptyRefStruct',
+    new OmitEmptyRefStruct(),
+    [],
+    OmitEmptyRefStruct,
+    [
+      {
+        name: 'Ptr',
+        key: 'Ptr',
+        type: {
+          kind: $.TypeKind.Pointer,
+          elemType: { kind: $.TypeKind.Basic, name: 'int' },
+        },
+        tag: 'json:"ptr,omitempty"',
+      },
+      {
+        name: 'Any',
+        key: 'Any',
+        type: { kind: $.TypeKind.Interface },
+        tag: 'json:"any,omitempty"',
+      },
+      {
+        name: 'Count',
+        key: 'Count',
+        type: { kind: $.TypeKind.Basic, name: 'int64' },
+        tag: 'json:"count,omitempty"',
+      },
+    ],
+  )
+}
+
 describe('encoding/json override', () => {
   it('registers the Unmarshaler interface shape', () => {
     class CustomMarshaler implements Marshaler {
@@ -221,6 +259,42 @@ describe('encoding/json override', () => {
     expect($.bytesToString(data)).toBe(
       '{"name":"Ada","age":30,"tags":["x"],"data":"eA=="}',
     )
+  })
+
+  it('omits nil pointers/interfaces but keeps non-nil ones holding a zero value', () => {
+    const zero = new OmitEmptyRefStruct()
+    const [zeroData, zeroErr] = Marshal(zero)
+    expect(zeroErr).toBeNull()
+    expect($.bytesToString(zeroData)).toBe('{}')
+
+    // A non-nil pointer to 0 and a non-nil interface holding 0 are not empty:
+    // only the pointer/interface itself being nil is empty, not its contents.
+    const filled = new OmitEmptyRefStruct()
+    filled._fields.Ptr.value = $.varRef(0)
+    filled._fields.Any.value = 0
+    const [data, err] = Marshal(filled)
+    expect(err).toBeNull()
+    expect($.bytesToString(data)).toBe('{"ptr":0,"any":0}')
+  })
+
+  it('treats a zero bigint as empty for omitempty', () => {
+    const zero = new OmitEmptyRefStruct()
+    const [zeroData, zeroErr] = Marshal(zero)
+    expect(zeroErr).toBeNull()
+    expect($.bytesToString(zeroData)).toBe('{}')
+
+    const nonZero = new OmitEmptyRefStruct()
+    nonZero._fields.Count.value = 5n
+    const [data, err] = Marshal(nonZero)
+    expect(err).toBeNull()
+    expect($.bytesToString(data)).toBe('{"count":5}')
+
+    // A non-nil interface holding a zero bigint is still non-empty.
+    const boxedZero = new OmitEmptyRefStruct()
+    boxedZero._fields.Any.value = 0n
+    const [boxedData, boxedErr] = Marshal(boxedZero)
+    expect(boxedErr).toBeNull()
+    expect($.bytesToString(boxedData)).toBe('{"any":0}')
   })
 
   it('unwraps a boxed interface{} value before marshaling instead of leaking its wrapper', () => {

--- a/gs/encoding/json/index.test.ts
+++ b/gs/encoding/json/index.test.ts
@@ -244,6 +244,16 @@ describe('encoding/json override', () => {
     expect($.bytesToString(holderData)).toBe('{"FullName":"active"}')
   })
 
+  it('does not mistake an ordinary object with a __goValue key for a box', () => {
+    // Only the runtime's actual boxed shape (string __goType plus __goValue,
+    // see isNamedValueBox in gs/builtin/type.ts) may be unwrapped. A plain JS
+    // object that merely has a __goValue property is legal Marshal input and
+    // must serialize as-is.
+    const [data, err] = Marshal({ __goValue: 5 })
+    expect(err).toBeNull()
+    expect($.bytesToString(data)).toBe('{"__goValue":5}')
+  })
+
   it('rejects unsupported values and invalid unmarshal targets', () => {
     const [nanData, nanErr] = Marshal(Number.NaN)
     expect(nanData).toBeNull()

--- a/gs/encoding/json/index.ts
+++ b/gs/encoding/json/index.ts
@@ -877,6 +877,18 @@ function marshalValue(v: unknown): unknown {
   if ($.isVarRef(v)) {
     return marshalValue(v.value)
   }
+  // Unwrap a boxed interface{} value (a named/defined type's value, boxed by
+  // the runtime as { __goType, __goValue, ... } so it can carry methods)
+  // before serializing; otherwise the wrapper object itself leaks into the
+  // output instead of the underlying primitive/map/slice it holds.
+  if (
+    typeof v === 'object' &&
+    v !== null &&
+    '__goValue' in v &&
+    !isStructValue(v)
+  ) {
+    return marshalValue((v as { __goValue: unknown }).__goValue)
+  }
   if (v === null || v === undefined) {
     return null
   }
@@ -916,9 +928,53 @@ function marshalValue(v: unknown): unknown {
     if (jsonName === '') {
       continue
     }
+    if (jsonOmitEmpty(field.tag) && isEmptyValue(ref.value)) {
+      continue
+    }
     out[jsonName] = marshalFieldValue(ref.value, field.type)
   }
   return out
+}
+
+// jsonOmitEmpty reports whether the struct tag carries the `,omitempty` option.
+function jsonOmitEmpty(tag: string | undefined): boolean {
+  if (tag === undefined || !tag.startsWith('json:"')) {
+    return false
+  }
+  const end = tag.indexOf('"', 'json:"'.length)
+  if (end < 0) {
+    return false
+  }
+  return tag
+    .slice('json:"'.length, end)
+    .split(',')
+    .slice(1)
+    .includes('omitempty')
+}
+
+// isEmptyValue mirrors Go encoding/json: zero numbers/strings/bools, empty
+// slices/maps/arrays, and nil pointers/interfaces are "empty".
+function isEmptyValue(v: unknown): boolean {
+  const t = $.isVarRef(v) ? (v as $.VarRef<unknown>).value : v
+  if (t === null || t === undefined) {
+    return true
+  }
+  if (typeof t === 'number') {
+    return t === 0
+  }
+  if (typeof t === 'string') {
+    return t === ''
+  }
+  if (typeof t === 'boolean') {
+    return t === false
+  }
+  if (Array.isArray(t)) {
+    return t.length === 0
+  }
+  if (t instanceof Map) {
+    return t.size === 0
+  }
+  return false
 }
 
 function marshalFieldValue(value: unknown, fieldType: unknown): unknown {

--- a/gs/encoding/json/index.ts
+++ b/gs/encoding/json/index.ts
@@ -968,7 +968,7 @@ function isEmptyValue(v: unknown): boolean {
   if (typeof t === 'boolean') {
     return t === false
   }
-  if (Array.isArray(t)) {
+  if (Array.isArray(t) || t instanceof Uint8Array) {
     return t.length === 0
   }
   if (t instanceof Map) {

--- a/gs/encoding/json/index.ts
+++ b/gs/encoding/json/index.ts
@@ -926,7 +926,7 @@ function marshalValue(v: unknown): unknown {
     if (jsonName === '') {
       continue
     }
-    if (jsonOmitEmpty(field.tag) && isEmptyValue(ref.value)) {
+    if (jsonOmitEmpty(field.tag) && isEmptyValue(ref.value, field.type)) {
       continue
     }
     out[jsonName] = marshalFieldValue(ref.value, field.type)
@@ -951,14 +951,23 @@ function jsonOmitEmpty(tag: string | undefined): boolean {
 }
 
 // isEmptyValue mirrors Go encoding/json: zero numbers/strings/bools, empty
-// slices/maps/arrays, and nil pointers/interfaces are "empty".
-function isEmptyValue(v: unknown): boolean {
+// slices/maps/arrays, and nil pointers/interfaces are "empty". Pointer and
+// interface fields are only empty when the pointer/interface itself is nil;
+// a non-nil pointer or interface is never empty, even when it points to or
+// holds a zero value, so those field types must not be unwrapped further.
+function isEmptyValue(v: unknown, fieldType?: unknown): boolean {
   const t = $.isVarRef(v) ? (v as $.VarRef<unknown>).value : v
+  if (isPointerOrInterfaceFieldType(fieldType)) {
+    return t === null || t === undefined
+  }
   if (t === null || t === undefined) {
     return true
   }
   if (typeof t === 'number') {
     return t === 0
+  }
+  if (typeof t === 'bigint') {
+    return t === 0n
   }
   if (typeof t === 'string') {
     return t === ''
@@ -973,6 +982,14 @@ function isEmptyValue(v: unknown): boolean {
     return t.size === 0
   }
   return false
+}
+
+function isPointerOrInterfaceFieldType(fieldType: unknown): boolean {
+  if (fieldType === null || typeof fieldType !== 'object') {
+    return false
+  }
+  const kind = Reflect.get(fieldType, 'kind')
+  return kind === $.TypeKind.Pointer || kind === $.TypeKind.Interface
 }
 
 function marshalFieldValue(value: unknown, fieldType: unknown): unknown {

--- a/gs/encoding/json/index.ts
+++ b/gs/encoding/json/index.ts
@@ -882,9 +882,7 @@ function marshalValue(v: unknown): unknown {
   // before serializing; otherwise the wrapper object itself leaks into the
   // output instead of the underlying primitive/map/slice it holds.
   if (
-    typeof v === 'object' &&
-    v !== null &&
-    '__goValue' in v &&
+    $.isNamedValueBox(v) &&
     !isStructValue(v)
   ) {
     return marshalValue((v as { __goValue: unknown }).__goValue)


### PR DESCRIPTION
Part of #142 (items 1 and 2). Independent of #143 (different area of the codebase). Touches `gs/encoding/json/index.ts` like #145 and #146, but a different area (`Marshal`'s encode path vs their `Unmarshal` decode path); `index.ts` itself merges cleanly, only the shared `index.test.ts` has a trivial fixture-insertion conflict (see #145's note).

Two separate `Marshal` bugs, grouped into one PR because both live in `marshalValue`/`assignStructFields` and are small on their own.

First, `,omitempty` struct tags were ignored: fields tagged `,omitempty` were emitted unconditionally, even when holding a Go zero value (zero number, empty string, `false`, empty slice/map, nil pointer/interface).

```go
type Config struct {
    Name string `json:"name,omitempty"`
}
b, _ := json.Marshal(Config{})
// got:  {"name":""}
// want: {}
```

Second, a boxed `interface{}` value leaked its wrapper into the output. The runtime boxes a named/defined type's value stored in an interface as `{ __goType, __goValue, ... }` so it can carry methods (`namedValueInterfaceValue` in `gs/builtin/type.ts`), and `marshalValue` serialized that wrapper object directly instead of the value it holds.

```go
type Status int
var v any = Status(2) // boxed as {__goType, __goValue: 2, ...}
b, _ := json.Marshal(v)
// got:  {"__goType":"...","__goValue":2,...} plus invalid-JSON garbage
//       from the wrapper's non-JSON-able method/valueOf/toString props
// want: 2
```

The fix adds `jsonOmitEmpty` (parses the tag's option list) and `isEmptyValue` (mirrors Go's zero-value rules for numbers, strings, bools, slices, maps, `Uint8Array` as `[]byte`, and nil); a field is skipped when both hold. `marshalValue` now unwraps `__goValue` (recursively, in case of nesting) before falling through to primitive/slice/map/struct handling, guarded by `!isStructValue(v)` so a real struct value is never mistaken for a wrapper.

Tests extend `gs/encoding/json/index.test.ts` with zero-valued vs populated `omitempty` fields (string/int/slice/`[]byte`) and a boxed primitive at the top level and nested inside a struct field. All new assertions fail on `master` and pass with this fix.

Verify:

```
bun run vitest run gs/encoding/json/index.test.ts
```

20 passed. Full suite: `bun run typecheck` clean, `bun run test:js` 1273 passed / 4 skipped / 0 failed, `go test ./...` all packages green, `bun run lint:js` clean.

Found while transpiling and running a real ~100k-LOC Go interpreter/parser package through goscript.
