### PR TITLE
fix(encoding/json): type-drive Unmarshal into Map/Slice/Pointer containers

### DIFF
--- a/gs/encoding/json/index.test.ts
+++ b/gs/encoding/json/index.test.ts
@@ -527,6 +527,58 @@ describe('encoding/json override', () => {
     )
   })
 
+  it('decodes pointer-to-struct values as unmarked pointees, matching *Struct not Struct by value', () => {
+    const target = $.varRef(new Schema())
+    const err = Unmarshal(
+      $.stringToBytes(
+        '{"properties":{"width":{"type":"number"}},"items":{"type":"string"}}',
+      ),
+      target,
+    )
+    expect(err).toBeNull()
+
+    const propertyType = $.getTypeByName('test.Property') as $.TypeInfo
+    const propertyPointerType: $.TypeInfo = {
+      kind: $.TypeKind.Pointer,
+      elemType: propertyType,
+    }
+
+    // A *Property field/map-value must match *Property (pointer), not
+    // Property (value): the runtime distinguishes pointer vs. value structs
+    // with a marker, and getting this wrong breaks Go type
+    // assertions/switches and pointer-receiver method-set checks on
+    // JSON-decoded values.
+    const items = target.value._fields.Items.value
+    expect($.is(items, propertyPointerType)).toBe(true)
+    expect($.is(items, propertyType)).toBe(false)
+
+    const width = target.value._fields.Properties.value?.get('width')
+    expect($.is(width, propertyPointerType)).toBe(true)
+    expect($.is(width, propertyType)).toBe(false)
+  })
+
+  it('preserves pointer element types when parsing a top-level __goType spelling', () => {
+    // Regression: parsing a __goType spelling used to strip every leading
+    // '*' while recursing into nested element types, collapsing
+    // map[string]*test.Property's element type down to test.Property and
+    // losing pointer-vs-value semantics for the decoded elements.
+    const target = $.varRef<Map<string, Property | null> | null>(new Map())
+    target.__goType = '*map[string]*test.Property'
+    expect(
+      Unmarshal($.stringToBytes('{"width":{"type":"number"}}'), target),
+    ).toBeNull()
+
+    const propertyType = $.getTypeByName('test.Property') as $.TypeInfo
+    const propertyPointerType: $.TypeInfo = {
+      kind: $.TypeKind.Pointer,
+      elemType: propertyType,
+    }
+    const width = target.value?.get('width')
+    expect(width?._fields.Type.value).toBe('number')
+    expect($.is(width, propertyPointerType)).toBe(true)
+    expect($.is(width, propertyType)).toBe(false)
+  })
+
   it('decodes json.RawMessage as a map and slice element type', () => {
     // The runtime boxes Unmarshal's `any` target with its Go type spelling
     // (__goType) at the call site; simulate that here the way $.interfaceValue

--- a/gs/encoding/json/index.test.ts
+++ b/gs/encoding/json/index.test.ts
@@ -182,6 +182,46 @@ class Schema {
   )
 }
 
+class HookPointee {
+  public _fields = {}
+  public Text = ''
+  public Marker = ''
+
+  UnmarshalJSON(data: $.Slice<number>): $.GoError {
+    this.Text = $.bytesToString(data)
+    return null
+  }
+
+  static __typeInfo = $.registerStructType(
+    'test.HookPointee',
+    new HookPointee(),
+    [],
+    HookPointee,
+    [],
+  )
+}
+
+class HookHolder {
+  public _fields = {
+    Hook: $.varRef<HookPointee | null>(null),
+  }
+
+  static __typeInfo = $.registerStructType(
+    'test.HookHolder',
+    new HookHolder(),
+    [],
+    HookHolder,
+    [
+      {
+        name: 'Hook',
+        key: 'Hook',
+        type: { kind: $.TypeKind.Pointer, elemType: 'test.HookPointee' },
+        tag: 'json:"hook"',
+      },
+    ],
+  )
+}
+
 class Holder {
   public _fields = {
     Value: $.varRef<unknown>(null),
@@ -525,6 +565,32 @@ describe('encoding/json override', () => {
     expect(target.value._fields.Items.value?._fields.Type.value).toBe(
       'string',
     )
+  })
+
+  it('allocates a nil pointer-to-struct field and invokes UnmarshalJSON on it, instead of decoding it field-by-field', () => {
+    const target = $.varRef(new HookHolder())
+    const err = Unmarshal($.stringToBytes('{"hook":{"nested":true}}'), target)
+
+    expect(err).toBeNull()
+    expect(target.value._fields.Hook.value).toBeInstanceOf(HookPointee)
+    expect(target.value._fields.Hook.value?.Text).toBe('{"nested":true}')
+  })
+
+  it('invokes UnmarshalJSON on a non-nil pointer-to-struct field in place, instead of replacing it with a freshly decoded instance', () => {
+    const holder = new HookHolder()
+    const existing = new HookPointee()
+    existing.Marker = 'orig'
+    holder._fields.Hook.value = existing
+
+    const target = $.varRef(holder)
+    const err = Unmarshal($.stringToBytes('{"hook":{"nested":true}}'), target)
+
+    expect(err).toBeNull()
+    // Go's encoding/json decodes into the existing pointee via its
+    // UnmarshalJSON hook, it never discards it for a fresh replacement.
+    expect(target.value._fields.Hook.value).toBe(existing)
+    expect(target.value._fields.Hook.value?.Marker).toBe('orig')
+    expect(target.value._fields.Hook.value?.Text).toBe('{"nested":true}')
   })
 
   it('decodes pointer-to-struct values as unmarked pointees, matching *Struct not Struct by value', () => {

--- a/gs/encoding/json/index.test.ts
+++ b/gs/encoding/json/index.test.ts
@@ -85,6 +85,124 @@ class FieldAlias {
   )
 }
 
+class Ref {
+  public _fields = {
+    Name: $.varRef(''),
+  }
+
+  static __typeInfo = $.registerStructType(
+    'test.Ref',
+    new Ref(),
+    [],
+    Ref,
+    [
+      {
+        name: 'Name',
+        key: 'Name',
+        type: { kind: $.TypeKind.Basic, name: 'string' },
+        tag: 'json:"name"',
+      },
+    ],
+  )
+}
+
+class Container {
+  public _fields = {
+    Contexts: $.varRef<Map<string, Ref[]> | null>(null),
+  }
+
+  static __typeInfo = $.registerStructType(
+    'test.Container',
+    new Container(),
+    [],
+    Container,
+    [
+      {
+        name: 'Contexts',
+        key: 'Contexts',
+        type: {
+          kind: $.TypeKind.Map,
+          elemType: { kind: $.TypeKind.Slice, elemType: 'test.Ref' },
+        },
+        tag: 'json:"contexts"',
+      },
+    ],
+  )
+}
+
+class Property {
+  public _fields = {
+    Type: $.varRef(''),
+  }
+
+  static __typeInfo = $.registerStructType(
+    'test.Property',
+    new Property(),
+    [],
+    Property,
+    [
+      {
+        name: 'Type',
+        key: 'Type',
+        type: { kind: $.TypeKind.Basic, name: 'string' },
+        tag: 'json:"type"',
+      },
+    ],
+  )
+}
+
+class Schema {
+  public _fields = {
+    Properties: $.varRef<Map<string, Property | null> | null>(null),
+    Items: $.varRef<Property | null>(null),
+  }
+
+  static __typeInfo = $.registerStructType(
+    'test.Schema',
+    new Schema(),
+    [],
+    Schema,
+    [
+      {
+        name: 'Properties',
+        key: 'Properties',
+        type: {
+          kind: $.TypeKind.Map,
+          elemType: { kind: $.TypeKind.Pointer, elemType: 'test.Property' },
+        },
+        tag: 'json:"properties"',
+      },
+      {
+        name: 'Items',
+        key: 'Items',
+        type: { kind: $.TypeKind.Pointer, elemType: 'test.Property' },
+        tag: 'json:"items"',
+      },
+    ],
+  )
+}
+
+class Holder {
+  public _fields = {
+    Value: $.varRef<unknown>(null),
+  }
+
+  static __typeInfo = $.registerStructType(
+    'test.Holder',
+    new Holder(),
+    [],
+    Holder,
+    [
+      {
+        name: 'Value',
+        key: 'Value',
+        type: { kind: $.TypeKind.Interface, methods: [] },
+        tag: 'json:"value"',
+      },
+    ],
+  )
+}
+
 describe('encoding/json override', () => {
   it('registers the Unmarshaler interface shape', () => {
     class CustomMarshaler implements Marshaler {
@@ -359,6 +477,75 @@ describe('encoding/json override', () => {
     expect(mapRef.value?.get('name')).toBe('Carol')
     expect(mapRef.value?.get('age')).toBe(22)
     expect(mapRef.value?.get('active')).toBe(true)
+  })
+
+  it('decodes a map[string][]Struct field into real struct instances, not plain objects/arrays', () => {
+    const target = $.varRef(new Container())
+    const err = Unmarshal(
+      $.stringToBytes('{"contexts":{"a":[{"name":"x"},{"name":"y"}]}}'),
+      target,
+    )
+
+    expect(err).toBeNull()
+    const contexts = target.value._fields.Contexts.value
+    expect(contexts).toBeInstanceOf(Map)
+    const refs = contexts?.get('a')
+    expect(refs).toHaveLength(2)
+    expect(refs?.[0]._fields.Name.value).toBe('x')
+    expect(refs?.[1]._fields.Name.value).toBe('y')
+  })
+
+  it('decodes array elements inside an interface{}-typed field into Maps, not plain objects', () => {
+    const target = $.varRef(new Holder())
+    const err = Unmarshal(
+      $.stringToBytes('{"value":[{"x":1},{"y":2}]}'),
+      target,
+    )
+
+    expect(err).toBeNull()
+    const value = target.value._fields.Value.value as unknown[]
+    expect(Array.isArray(value)).toBe(true)
+    expect(value[0]).toBeInstanceOf(Map)
+    expect((value[0] as Map<string, unknown>).get('x')).toBe(1)
+    expect((value[1] as Map<string, unknown>).get('y')).toBe(2)
+  })
+
+  it('decodes pointer-to-struct map values and fields into real struct instances', () => {
+    const target = $.varRef(new Schema())
+    const err = Unmarshal(
+      $.stringToBytes(
+        '{"properties":{"width":{"type":"number"}},"items":{"type":"string"}}',
+      ),
+      target,
+    )
+
+    expect(err).toBeNull()
+    const properties = target.value._fields.Properties.value
+    expect(properties?.get('width')?._fields.Type.value).toBe('number')
+    expect(target.value._fields.Items.value?._fields.Type.value).toBe(
+      'string',
+    )
+  })
+
+  it('decodes json.RawMessage as a map and slice element type', () => {
+    // The runtime boxes Unmarshal's `any` target with its Go type spelling
+    // (__goType) at the call site; simulate that here the way $.interfaceValue
+    // would for `var m map[string]json.RawMessage; json.Unmarshal(data, &m)`.
+    const mapTarget = $.varRef<Map<string, Uint8Array> | null>(new Map())
+    mapTarget.__goType = '*map[string]json.RawMessage'
+    expect(
+      Unmarshal($.stringToBytes('{"a":{"x":1},"b":[1,2,3]}'), mapTarget),
+    ).toBeNull()
+    expect($.bytesToString(mapTarget.value!.get('a')!)).toBe('{"x":1}')
+    expect($.bytesToString(mapTarget.value!.get('b')!)).toBe('[1,2,3]')
+
+    const sliceTarget = $.varRef<Uint8Array[]>([])
+    sliceTarget.__goType = '*[]json.RawMessage'
+    expect(
+      Unmarshal($.stringToBytes('[{"x":1},"raw"]'), sliceTarget),
+    ).toBeNull()
+    expect($.bytesToString(sliceTarget.value[0])).toBe('{"x":1}')
+    expect($.bytesToString(sliceTarget.value[1])).toBe('"raw"')
   })
 
   it('encodes JSON to an io.Writer with newline, indentation, and HTML escaping', () => {

--- a/gs/encoding/json/index.ts
+++ b/gs/encoding/json/index.ts
@@ -1116,6 +1116,16 @@ function assignDecodedFieldValue(
     if ($.isPointerTypeInfo(info) && isPlainObject(decoded)) {
       const pointee = resolveTypeInfo(info.elemType)
       if (pointee !== null && $.isStructTypeInfo(pointee)) {
+        // A field that already holds a non-nil pointer whose pointee
+        // implements UnmarshalJSON must still go through that hook: Go's
+        // encoding/json always prefers a custom decoder over field-by-field
+        // population, even when the field is pre-populated rather than nil.
+        // The type-driven constructor below only sees a fresh instance it
+        // allocates itself, so it cannot see this pre-existing target.
+        if (unmarshalJSONTarget(target.value) !== null) {
+          assignDecodedValue(target, decoded, opts)
+          return
+        }
         target.value = decodeValueForType(decoded, info, opts)
         return
       }
@@ -1190,6 +1200,21 @@ function decodeValueForType(
         return decoded
       }
       const inst = new pointee.ctor()
+      // A freshly-allocated pointee that implements UnmarshalJSON must be
+      // decoded through that hook rather than field-by-field, mirroring Go:
+      // encoding/json always prefers a custom decoder over the default
+      // struct decode, including for a pointer field/element it allocates
+      // itself.
+      const unmarshaler = unmarshalJSONTarget(inst)
+      if (unmarshaler !== null) {
+        const err = unmarshaler.UnmarshalJSON(
+          $.stringToBytes(JSON.stringify(decoded)),
+        )
+        if (err !== null) {
+          throw err
+        }
+        return inst
+      }
       if (isStructValue(inst)) {
         assignStructFields(inst, decoded, opts)
       }

--- a/gs/encoding/json/index.ts
+++ b/gs/encoding/json/index.ts
@@ -1108,12 +1108,15 @@ function assignDecodedFieldValue(
     }
     // Pointer-to-struct fields (e.g. Items *ItemsSpec) start as nil, so the
     // generic path below has no zero-value instance to populate — construct
-    // the pointee via the type-driven decoder. Pointer-to-basic fields keep
-    // the generic path (their representation is not a struct instance).
+    // the pointee via the type-driven decoder. Decode with the Pointer
+    // TypeInfo itself (not its elemType) so decodeValueForType's Pointer
+    // branch handles the pointer-vs-value marking correctly; see its
+    // comment. Pointer-to-basic fields keep the generic path (their
+    // representation is not a struct instance).
     if ($.isPointerTypeInfo(info) && isPlainObject(decoded)) {
       const pointee = resolveTypeInfo(info.elemType)
       if (pointee !== null && $.isStructTypeInfo(pointee)) {
-        target.value = decodeValueForType(decoded, info.elemType, opts)
+        target.value = decodeValueForType(decoded, info, opts)
         return
       }
     }
@@ -1174,6 +1177,26 @@ function decodeValueForType(
     return decodeInterfaceValue(decoded)
   }
   if ($.isPointerTypeInfo(info)) {
+    // A *Struct pointee must be constructed directly here, NOT by recursing
+    // into the Struct branch below: that branch always marks its result via
+    // $.markAsStructValue, but the runtime's pointer matching
+    // (matchesPointerType in gs/builtin/type.ts) requires struct pointees to
+    // stay UNMARKED — only a genuine non-pointer struct value is marked.
+    // Getting this wrong breaks *Struct type assertions/switches and
+    // pointer-receiver method-set checks on decoded values.
+    const pointee = resolveTypeInfo(info.elemType)
+    if (pointee !== null && $.isStructTypeInfo(pointee)) {
+      if (!isPlainObject(decoded) || typeof pointee.ctor !== 'function') {
+        return decoded
+      }
+      const inst = new pointee.ctor()
+      if (isStructValue(inst)) {
+        assignStructFields(inst, decoded, opts)
+      }
+      return inst
+    }
+    // Non-struct pointee (e.g. *string): decode as the pointee's own
+    // representation, which carries no pointer-vs-value marking.
     return decodeValueForType(decoded, info.elemType, opts)
   }
   if ($.isStructTypeInfo(info)) {
@@ -1252,15 +1275,27 @@ function unmarshalTargetGoType(target: unknown): string | null {
 
 // goTypeDescriptor parses a Go type spelling (from __goType, see above) into
 // a decode descriptor consumable by decodeValueForType / resolveTypeInfo:
+//   - {kind: Pointer, elemType}   for *T (e.g. a map[string]*T element
+//                                 spelling) — NOT stripped, so
+//                                 decodeValueForType's Pointer branch can
+//                                 apply the correct pointer-vs-value marking
+//                                 (see its comment). Only the single
+//                                 outermost star representing the Unmarshal
+//                                 target's own address-of is stripped, by
+//                                 unmarshalTargetGoType above, before this
+//                                 function ever runs.
 //   - 'json.RawMessage'          RawMessage marker (isRawMessageType)
 //   - {kind: Slice|Map, elemType} for []T / map[K]V
 //   - the spelling itself         for named types ($.getTypeByName resolves)
 //   - null                        for interface{} and unparseable spellings
 //                                 (shape-driven decode, same as before)
 function goTypeDescriptor(spelling: string): unknown {
-  let s = spelling.trim()
-  while (s.startsWith('*')) {
-    s = s.slice(1).trim()
+  const s = spelling.trim()
+  if (s.startsWith('*')) {
+    return {
+      kind: $.TypeKind.Pointer,
+      elemType: goTypeDescriptor(s.slice(1).trim()),
+    }
   }
   if (s === 'json.RawMessage' || s === 'encoding/json.RawMessage') {
     return 'json.RawMessage'

--- a/gs/encoding/json/index.ts
+++ b/gs/encoding/json/index.ts
@@ -1013,8 +1013,29 @@ function assignDecodedValue(
       target.value = base64Decode(decoded)
       return
     }
-    if (isPlainObject(decoded)) {
-      target.value = objectToMap(decoded)
+    // A top-level map/slice var carries its Go type spelling (including its
+    // element type) via __goType, which the runtime boxes onto Unmarshal's
+    // `any` target (see unmarshalTargetGoType/goTypeDescriptor below).
+    // Decoding per that spelling, instead of the shape-driven decode below,
+    // is what makes e.g. `var m map[string]json.RawMessage` or
+    // `var m map[string]*Property` populate real typed elements instead of
+    // plain JS objects/strings.
+    const spelling = unmarshalTargetGoType(target)
+    if (spelling !== null) {
+      const desc = goTypeDescriptor(spelling)
+      const info = resolveTypeInfo(desc)
+      if (info !== null) {
+        if (
+          ($.isSliceTypeInfo(info) && Array.isArray(decoded)) ||
+          ($.isMapTypeInfo(info) && isPlainObject(decoded))
+        ) {
+          target.value = decodeValueForType(decoded, desc, opts)
+          return
+        }
+      }
+    }
+    if (isPlainObject(decoded) || Array.isArray(decoded)) {
+      target.value = decodeInterfaceValue(decoded)
       return
     }
     target.value = decoded
@@ -1070,15 +1091,213 @@ function assignDecodedFieldValue(
     target.value = $.stringToBytes(JSON.stringify(decoded))
     return
   }
+  // Decode Map/Slice-typed fields (including nested combinations, e.g.
+  // map[string][]Struct) through the type-driven decoder below. Gated on the
+  // decoded JSON shape actually matching (array for Slice, object for Map) so
+  // every other field shape (basic types, []byte-as-base64-string, etc.)
+  // falls through to the untouched generic path exactly as before.
+  const info = resolveTypeInfo(fieldType)
+  if (info !== null) {
+    if ($.isSliceTypeInfo(info) && Array.isArray(decoded)) {
+      target.value = decodeValueForType(decoded, info, opts)
+      return
+    }
+    if ($.isMapTypeInfo(info) && isPlainObject(decoded)) {
+      target.value = decodeValueForType(decoded, info, opts)
+      return
+    }
+    // Pointer-to-struct fields (e.g. Items *ItemsSpec) start as nil, so the
+    // generic path below has no zero-value instance to populate — construct
+    // the pointee via the type-driven decoder. Pointer-to-basic fields keep
+    // the generic path (their representation is not a struct instance).
+    if ($.isPointerTypeInfo(info) && isPlainObject(decoded)) {
+      const pointee = resolveTypeInfo(info.elemType)
+      if (pointee !== null && $.isStructTypeInfo(pointee)) {
+        target.value = decodeValueForType(decoded, info.elemType, opts)
+        return
+      }
+    }
+  }
   assignDecodedValue(target, decoded, opts)
 }
 
-function objectToMap(decoded: Record<string, unknown>): Map<string, unknown> {
-  const out = new Map<string, unknown>()
-  for (const [key, value] of Object.entries(decoded)) {
-    out.set(key, isPlainObject(value) ? objectToMap(value) : value)
+// resolveTypeInfo normalizes a type descriptor (an inline TypeInfo object, or
+// a qualified type-name string like "pkg.MyStruct") into a TypeInfo, looking
+// up named types via $.getTypeByName. Returns null when the descriptor is
+// missing or names a type the runtime has no registration for (e.g. a basic
+// type name like "uint8" — those are handled as plain values).
+function resolveTypeInfo(t: unknown): $.TypeInfo | null {
+  if (typeof t === 'string') {
+    return ($.getTypeByName(t) as $.TypeInfo | undefined) ?? null
   }
-  return out
+  if (typeof t === 'object' && t !== null && 'kind' in t) {
+    return t as $.TypeInfo
+  }
+  return null
+}
+
+// decodeValueForType recursively decodes a raw JSON-parsed JS value into a
+// properly-typed Go value per `typeInfo`:
+//   - Struct: construct the registered ctor and populate its fields.
+//   - Slice: decode each element per the slice's elemType (struct elements
+//     become real struct instances instead of leaking plain objects).
+//   - Map: build a real Map (this override's Go-map representation) whose
+//     values are decoded per the map's elemType — this is what fixes
+//     map[string]T struct/slice-of-struct fields (e.g. a
+//     `Contexts map[string][]Ref` field): a struct- or slice-valued MAP
+//     field previously fell through to the shape-driven interface{} decode
+//     below and silently produced a Map of plain JS objects/arrays instead
+//     of real struct instances, so Go field access on the decoded values
+//     (e.g. `contexts.Foo`) read back empty/undefined.
+//   - json.RawMessage element: captures the raw JSON fragment as bytes,
+//     mirroring the direct-struct-field RawMessage path in
+//     assignDecodedFieldValue above.
+//   - Pointer element: decodes as its pointee (the runtime represents a
+//     *Struct value as the struct instance itself for field access) —
+//     without this, map/slice elements typed e.g. map[string]*Property
+//     leaked plain objects whose Go field reads came back undefined.
+//   - Missing type info / interface{} elements: shape-driven decode via
+//     decodeInterfaceValue, mirroring Go's json.Unmarshal-into-any.
+function decodeValueForType(
+  decoded: unknown,
+  typeInfo: unknown,
+  opts: decodeOptions,
+): unknown {
+  if (isRawMessageType(typeInfo) && decoded !== undefined) {
+    return $.stringToBytes(JSON.stringify(decoded))
+  }
+  if (decoded === null || decoded === undefined) {
+    return decoded
+  }
+  const info = resolveTypeInfo(typeInfo)
+  if (info === null || $.isInterfaceTypeInfo(info)) {
+    return decodeInterfaceValue(decoded)
+  }
+  if ($.isPointerTypeInfo(info)) {
+    return decodeValueForType(decoded, info.elemType, opts)
+  }
+  if ($.isStructTypeInfo(info)) {
+    if (!isPlainObject(decoded) || typeof info.ctor !== 'function') {
+      return decoded
+    }
+    const inst = new info.ctor()
+    if (isStructValue(inst)) {
+      assignStructFields(inst, decoded, opts)
+    }
+    return $.markAsStructValue(inst)
+  }
+  if ($.isSliceTypeInfo(info)) {
+    if (!Array.isArray(decoded)) {
+      return decoded
+    }
+    return decoded.map((el) => decodeValueForType(el, info.elemType, opts))
+  }
+  if ($.isMapTypeInfo(info)) {
+    if (!isPlainObject(decoded)) {
+      return decoded
+    }
+    const out = new Map<string, unknown>()
+    for (const [key, value] of Object.entries(decoded)) {
+      out.set(key, decodeValueForType(value, info.elemType, opts))
+    }
+    return out
+  }
+  // Basic / other kinds: passthrough (RawMessage and []byte-as-base64 are
+  // handled by the caller before reaching the generic decoder).
+  return decoded
+}
+
+// decodeInterfaceValue recursively decodes a raw JSON-parsed JS value the way
+// Go's json.Unmarshal decodes into interface{}: objects become Maps (this
+// override's Go-map representation) and arrays are decoded element-wise, so
+// nested objects INSIDE arrays also become Maps, not just direct object
+// values — both recursively, all the way down. Primitives pass through
+// unchanged.
+//
+// Supersedes objectToMap, which only recursed into direct object VALUES, not
+// array elements: an interface{}-typed array of objects (e.g. a Go []any
+// holding map[string]any elements) left its element objects as raw plain JS
+// objects instead of Maps. Go-side code that then type-switches on
+// `case map[string]any:` and calls Map-only methods like .entries() on those
+// elements panics with "entries is not a function".
+function decodeInterfaceValue(decoded: unknown): unknown {
+  if (Array.isArray(decoded)) {
+    return decoded.map((el) => decodeInterfaceValue(el))
+  }
+  if (isPlainObject(decoded)) {
+    const out = new Map<string, unknown>()
+    for (const [key, value] of Object.entries(decoded)) {
+      out.set(key, decodeInterfaceValue(value))
+    }
+    return out
+  }
+  return decoded
+}
+
+// unmarshalTargetGoType returns the Go type spelling the runtime's
+// $.interfaceValue boxes onto an Unmarshal target as __goType (e.g.
+// `*map[string]json.RawMessage`), without the leading pointer star. Null
+// when the target carries none (e.g. it was never passed through an `any`
+// parameter, so there is no spelling to decode against).
+function unmarshalTargetGoType(target: unknown): string | null {
+  if (target === null || typeof target !== 'object') {
+    return null
+  }
+  const t = Reflect.get(target, '__goType')
+  if (typeof t !== 'string' || t === '') {
+    return null
+  }
+  return t.startsWith('*') ? t.slice(1) : t
+}
+
+// goTypeDescriptor parses a Go type spelling (from __goType, see above) into
+// a decode descriptor consumable by decodeValueForType / resolveTypeInfo:
+//   - 'json.RawMessage'          RawMessage marker (isRawMessageType)
+//   - {kind: Slice|Map, elemType} for []T / map[K]V
+//   - the spelling itself         for named types ($.getTypeByName resolves)
+//   - null                        for interface{} and unparseable spellings
+//                                 (shape-driven decode, same as before)
+function goTypeDescriptor(spelling: string): unknown {
+  let s = spelling.trim()
+  while (s.startsWith('*')) {
+    s = s.slice(1).trim()
+  }
+  if (s === 'json.RawMessage' || s === 'encoding/json.RawMessage') {
+    return 'json.RawMessage'
+  }
+  if (s === 'any' || s === 'interface{}' || s === 'interface {}') {
+    return null
+  }
+  if (s.startsWith('[]')) {
+    return { kind: $.TypeKind.Slice, elemType: goTypeDescriptor(s.slice(2)) }
+  }
+  if (s.startsWith('map[')) {
+    const keyEnd = matchingBracketIndex(s, 'map['.length - 1)
+    if (keyEnd < 0) {
+      return null
+    }
+    return {
+      kind: $.TypeKind.Map,
+      elemType: goTypeDescriptor(s.slice(keyEnd + 1)),
+    }
+  }
+  return s
+}
+
+// matchingBracketIndex returns the index of the ']' matching the '[' at
+// `open`, or -1. Tracks nesting only — Go map key spellings carry no strings
+// or further brackets in the shapes goTypeDescriptor parses (map keys are
+// always basic types).
+function matchingBracketIndex(s: string, open: number): number {
+  let depth = 0
+  for (let i = open; i < s.length; i++) {
+    if (s[i] === '[') depth++
+    else if (s[i] === ']') {
+      depth--
+      if (depth === 0) return i
+    }
+  }
+  return -1
 }
 
 function isStructValue(


### PR DESCRIPTION
Part of #142 (items 3, 4 and 6).

Touches the same file as #144 but a different area (`Unmarshal`'s decode path vs `Marshal`'s encode path). `gs/encoding/json/index.ts` itself merges cleanly between the two branches; only the shared test file (`index.test.ts`) has a textual conflict, since both PRs happen to insert new test fixture classes right after the existing `FieldAlias` class, so whichever merges second needs a trivial resolution there (keep both class blocks). No logic overlap. #146 (item 5, anonymous struct json tags) is stacked directly on this branch, since it extends the same `goTypeDescriptor`/`decodeValueForType` this PR introduces, so please merge this one first.

`Unmarshal` only recognized a struct field/target as needing special handling when its runtime value was already an instance of the right shape (an existing struct instance, a `Uint8Array`, etc). Everything else fell through to a generic "objects become Maps" decode with no awareness of the field's declared Go element type. Three related gaps, all fixed by the same missing piece: decoding needs to walk the field/element's TypeInfo, not just the JSON shape it happens to see.

Gap 1: `map[string]Struct` and `map[string][]Struct` fields (and further nesting) left plain JS objects/arrays in place instead of real struct instances, so generated struct-field accessors read back `undefined`.

```go
type Ref struct{ Name string `json:"name"` }
type Container struct {
    Contexts map[string][]Ref `json:"contexts"`
}
json.Unmarshal([]byte(`{"contexts":{"a":[{"name":"x"}]}}`), &c)
// c.Contexts["a"][0].Name read back "": plain object, not a Ref
```

Gap 2: an `interface{}`-typed array of objects left its element objects as raw plain JS objects instead of this override's Map representation, so a `case map[string]any:` type switch on an element panicked calling Map-only methods like `.entries()`.

```go
var v any
json.Unmarshal([]byte(`[{"x":1},{"y":2}]`), &v)
// v.([]any)[0] was a plain object, not the Map every other
// interface{}-typed object value decodes to
```

Gap 3: `json.RawMessage` wasn't recognized as a map/slice element type (only as a direct field type), and there was no `Pointer` branch in the type-driven path at all, so pointer elements and fields (`map[string]*Property`, `Items *ItemsSpec`) leaked plain objects with undefined Go field reads.

The fix is a recursive `decodeValueForType(decoded, typeInfo, opts)` that decodes a raw JSON value per its Go `TypeInfo`: `Struct` constructs a real instance via the registered ctor, `Slice`/`Map` recurse per `elemType`, `Pointer` decodes as its pointee, `json.RawMessage` captures the raw fragment as bytes, and anything else (including `interface{}`) falls back to a new `decodeInterfaceValue`, which replaces `objectToMap` and additionally recurses into array elements, fixing gap 2 for both nested and top-level arrays. It is wired in at both call sites: `assignDecodedFieldValue` (struct fields) and `assignDecodedValue`'s new top-level branch, which resolves a var's own type via the `__goType` spelling the runtime boxes onto `Unmarshal`'s `any` target, needed for e.g. `var m map[string]json.RawMessage` where there is no struct field to hang type info off of.

A pointer-to-struct pointee is constructed directly in the Pointer branch (not by recursing into the Struct branch, which always marks its result via `$.markAsStructValue`): the runtime's pointer type matching (`matchesPointerType` in `gs/builtin/type.ts`) requires struct pointees to stay unmarked, so both `assignDecodedFieldValue`'s field routing and `decodeValueForType`'s own Pointer branch share this construction path. `goTypeDescriptor` also preserves a nested pointer element type (e.g. the `*test.Property` in `map[string]*test.Property`) instead of stripping every leading `*` while parsing; only the outermost address-of star (the `Unmarshal` target's own `&var`) is stripped, by `unmarshalTargetGoType`, before this function ever runs.

Tests extend `gs/encoding/json/index.test.ts` with one case per gap: `map[string][]Struct` field, `interface{}` array-of-objects, pointer-to-struct map value and field, `RawMessage` as both a map and slice element, and two cases verifying decoded pointer values match `*Struct` (not `Struct` by value) via the public `$.is()` API. All new tests fail on `master` (or the prior commit, for the pointer-marking cases) and pass with this fix, verified by temporarily reverting just the source change and confirming they fail with the errors described above.

Verify:

```
bun run vitest run gs/encoding/json/index.test.ts
```

24 passed. Full suite: `bun run typecheck` clean, `bun run test:js` 1277 passed / 4 skipped / 0 failed, `go test ./...` all packages green, `bun run lint:js` clean.

Found while transpiling and running a real ~100k-LOC Go interpreter/parser package through goscript.
