### PR TITLE
test(runtime): skip unavailable Playwright engines

### DIFF
--- a/gs/builtin/defer-browser.test.ts
+++ b/gs/builtin/defer-browser.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process'
-import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -28,29 +28,32 @@ describe.each([
   ['Chromium', chromium],
   ['WebKit', webkit],
 ])('DisposableStack in %s', (_name, browserType) => {
-  it('supports generated using declarations', async () => {
-    const browser = await browserType.launch({ headless: true })
-    const page = await browser.newPage()
-    const errors: string[] = []
-    page.on('pageerror', (error) => errors.push(error.message))
+  it.skipIf(!existsSync(browserType.executablePath()))(
+    'supports generated using declarations',
+    async () => {
+      const browser = await browserType.launch({ headless: true })
+      const page = await browser.newPage()
+      const errors: string[] = []
+      page.on('pageerror', (error) => errors.push(error.message))
 
-    try {
-      await page.addScriptTag({ content: bundle })
-      expect(errors).toEqual([])
-      expect(
-        await page.evaluate(
-          async () => await globalThis.__goscriptDisposableStackResult,
-        ),
-      ).toEqual({
-        disposeSymbolPresent: _name === 'Chromium',
-        asyncDisposeSymbolPresent: _name === 'Chromium',
-        usesDisposeSymbol: true,
-        usesAsyncDisposeSymbol: true,
-        order: ['second', 'first', 'async'],
-        disposeError: 'deferred failure',
-      })
-    } finally {
-      await browser.close()
-    }
-  })
+      try {
+        await page.addScriptTag({ content: bundle })
+        expect(errors).toEqual([])
+        expect(
+          await page.evaluate(
+            async () => await globalThis.__goscriptDisposableStackResult,
+          ),
+        ).toEqual({
+          disposeSymbolPresent: _name === 'Chromium',
+          asyncDisposeSymbolPresent: _name === 'Chromium',
+          usesDisposeSymbol: true,
+          usesAsyncDisposeSymbol: true,
+          order: ['second', 'first', 'async'],
+          disposeError: 'deferred failure',
+        })
+      } finally {
+        await browser.close()
+      }
+    },
+  )
 })


### PR DESCRIPTION
Default CI does not install Playwright browser executables, so the direct browser regression must skip rows whose engine is unavailable. The focused installed-engine environment still runs both Chromium and WebKit rows, retaining the proof for the disposable-symbol fix without changing the runtime source or browser fixture.