### PR TITLE
fix(wasivm): align browser host function contract

### DIFF
--- a/gs/context/context.ts
+++ b/gs/context/context.ts
@@ -269,7 +269,7 @@ export function TODO(): Context {
 }
 
 // WithCancel returns a copy of parent with a new Done channel
-export function WithCancel(parent: Context): [ContextNonNil, CancelFunc] {
+export function WithCancel(parent: Context): [Context, CancelFunc] {
   if (parent === null) {
     throw new Error('cannot create context from nil parent')
   }
@@ -285,9 +285,7 @@ export function WithCancel(parent: Context): [ContextNonNil, CancelFunc] {
 }
 
 // WithCancelCause returns a copy of parent with a new Done channel and cause recording
-export function WithCancelCause(
-  parent: Context,
-): [ContextNonNil, CancelCauseFunc] {
+export function WithCancelCause(parent: Context): [Context, CancelCauseFunc] {
   if (parent === null) {
     throw new Error('cannot create context from nil parent')
   }
@@ -306,7 +304,7 @@ export function WithCancelCause(
 export function WithDeadline(
   parent: Context,
   d: time.Time,
-): [ContextNonNil, CancelFunc] {
+): [Context, CancelFunc] {
   return WithDeadlineCause(parent, d, null)
 }
 
@@ -315,7 +313,7 @@ export function WithDeadlineCause(
   parent: Context,
   d: time.Time,
   cause: $.GoError,
-): [ContextNonNil, CancelFunc] {
+): [Context, CancelFunc] {
   if (parent === null) {
     throw new Error('cannot create context from nil parent')
   }
@@ -342,7 +340,7 @@ export function WithDeadlineCause(
 export function WithTimeout(
   parent: Context,
   timeout: time.Duration,
-): [ContextNonNil, CancelFunc] {
+): [Context, CancelFunc] {
   return WithDeadline(parent, time.Now().Add(timeout))
 }
 
@@ -351,12 +349,12 @@ export function WithTimeoutCause(
   parent: Context,
   timeout: time.Duration,
   cause: $.GoError,
-): [ContextNonNil, CancelFunc] {
+): [Context, CancelFunc] {
   return WithDeadlineCause(parent, time.Now().Add(timeout), cause)
 }
 
 // WithValue returns a copy of parent with the value associated with key
-export function WithValue(parent: Context, key: any, val: any): ContextNonNil {
+export function WithValue(parent: Context, key: any, val: any): Context {
   if (parent === null) {
     throw new Error('cannot create context from nil parent')
   }
@@ -364,7 +362,7 @@ export function WithValue(parent: Context, key: any, val: any): ContextNonNil {
 }
 
 // WithoutCancel returns a context that inherits values but not cancellation
-export function WithoutCancel(parent: Context): ContextNonNil {
+export function WithoutCancel(parent: Context): Context {
   if (parent === null) {
     throw new Error('cannot create context from nil parent')
   }

--- a/gs/github.com/aperturerobotics/wasivm/wazero/kernel/runtime/browser/browser.test.ts
+++ b/gs/github.com/aperturerobotics/wasivm/wazero/kernel/runtime/browser/browser.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from 'vitest'
+
+import * as $ from '@goscript/builtin/index.js'
+
+import { NewExitError, VmModuleConfig } from '../runtime.js'
+import { New } from './browser.js'
+
+const importedIncrementModule = new Uint8Array([
+  0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x06, 0x01, 0x60, 0x01,
+  0x7f, 0x01, 0x7f, 0x02, 0x0c, 0x01, 0x03, 0x65, 0x6e, 0x76, 0x04, 0x68, 0x6f,
+  0x73, 0x74, 0x00, 0x00, 0x03, 0x02, 0x01, 0x00, 0x07, 0x07, 0x01, 0x03, 0x72,
+  0x75, 0x6e, 0x00, 0x01, 0x0a, 0x08, 0x01, 0x06, 0x00, 0x41, 0x29, 0x10, 0x00,
+  0x0b,
+])
+
+const duplicateHostImportModule = new Uint8Array([
+  0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x0b, 0x02, 0x60, 0x01,
+  0x7f, 0x01, 0x7f, 0x60, 0x01, 0x7e, 0x01, 0x7e, 0x02, 0x17, 0x02, 0x03, 0x65,
+  0x6e, 0x76, 0x04, 0x68, 0x6f, 0x73, 0x74, 0x00, 0x00, 0x03, 0x65, 0x6e, 0x76,
+  0x04, 0x68, 0x6f, 0x73, 0x74, 0x00, 0x01, 0x07, 0x11, 0x02, 0x05, 0x72, 0x75,
+  0x6e, 0x33, 0x32, 0x00, 0x00, 0x05, 0x72, 0x75, 0x6e, 0x36, 0x34, 0x00, 0x01,
+])
+
+const i64IdentityModule = new Uint8Array([
+  0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x06, 0x01, 0x60, 0x01,
+  0x7e, 0x01, 0x7e, 0x03, 0x02, 0x01, 0x00, 0x07, 0x08, 0x01, 0x04, 0x69, 0x64,
+  0x36, 0x34, 0x00, 0x00, 0x0a, 0x06, 0x01, 0x04, 0x00, 0x20, 0x00, 0x0b,
+])
+
+const f32IdentityModule = i64IdentityModule.map((value) =>
+  value === 0x7e ? 0x7d : value,
+)
+const f64IdentityModule = i64IdentityModule.map((value) =>
+  value === 0x7e ? 0x7c : value,
+)
+
+const importedI64Module = new Uint8Array([
+  0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x06, 0x01, 0x60, 0x01,
+  0x7e, 0x01, 0x7e, 0x02, 0x0c, 0x01, 0x03, 0x65, 0x6e, 0x76, 0x04, 0x68, 0x6f,
+  0x73, 0x74, 0x00, 0x00, 0x03, 0x02, 0x01, 0x00, 0x07, 0x07, 0x01, 0x03, 0x72,
+  0x75, 0x6e, 0x00, 0x01, 0x0a, 0x08, 0x01, 0x06, 0x00, 0x20, 0x00, 0x10, 0x00,
+  0x0b,
+])
+
+async function instantiate(
+  wasm: Uint8Array,
+  hostFunction?: (
+    ctx: null,
+    instance: unknown,
+    stack: $.Slice<bigint>,
+  ) => $.GoError | Promise<$.GoError>,
+) {
+  const [module, compileErr] = await New().Compile(null, wasm)
+  expect(compileErr).toBeNull()
+  expect(module).not.toBeNull()
+
+  const hostFunctions =
+    hostFunction ? new Map([['env.host', hostFunction]]) : null
+  const [instance, instantiateErr] = await module!.Instantiate(
+    null,
+    new VmModuleConfig({ HostFunctions: hostFunctions }),
+  )
+  expect(instantiateErr).toBeNull()
+  expect(instance).not.toBeNull()
+  return instance!
+}
+
+describe('browser WASM host function contract', () => {
+  it('passes i32 stack values as bigint and returns error tuples', async () => {
+    const instance = await instantiate(
+      importedIncrementModule,
+      (_ctx, instance, stack) => {
+        expect(instance).not.toBeNull()
+        expect(stack?.[0]).toBe(41n)
+        if (stack) stack[0] = 42n
+        return null
+      },
+    )
+
+    const [results, callErr] = await instance.Call(null, 'run')
+    expect(callErr).toBeNull()
+    expect(results).toEqual([42n])
+  })
+
+  it('supports duplicate host imports with different signatures', async () => {
+    const i64Value = 0xf123456789abcdefn
+    const instance = await instantiate(
+      duplicateHostImportModule,
+      (_ctx, _instance, stack) => {
+        if (stack) stack[0] += 1n
+        return null
+      },
+    )
+
+    const [i32Results, i32Err] = await instance.Call(null, 'run32', 41n)
+    expect(i32Err).toBeNull()
+    expect(i32Results).toEqual([42n])
+
+    const [i64Results, i64Err] = await instance.Call(null, 'run64', i64Value)
+    expect(i64Err).toBeNull()
+    expect(i64Results).toEqual([i64Value + 1n])
+  })
+
+  it('preserves i64 arguments and results beyond Number precision', async () => {
+    const value = 0xf123456789abcdefn
+    const identity = await instantiate(i64IdentityModule)
+    const [identityResults, identityErr] = await identity.Call(
+      null,
+      'id64',
+      value,
+    )
+    expect(identityErr).toBeNull()
+    expect(identityResults).toEqual([value])
+
+    const imported = await instantiate(
+      importedI64Module,
+      (_ctx, _inst, stack) => {
+        expect(stack?.[0]).toBe(value)
+        if (stack) stack[0] ^= 0x00ff000000000000n
+        return null
+      },
+    )
+    const [importedResults, importedErr] = await imported.Call(
+      null,
+      'run',
+      value,
+    )
+    expect(importedErr).toBeNull()
+    expect(importedResults).toEqual([value ^ 0x00ff000000000000n])
+  })
+
+  it('preserves f32 and f64 stack representations', async () => {
+    const f32 = await instantiate(f32IdentityModule)
+    const [f32Results, f32Err] = await f32.Call(null, 'id64', 0x3fc00000n)
+    expect(f32Err).toBeNull()
+    expect(f32Results).toEqual([0x3fc00000n])
+
+    const f64 = await instantiate(f64IdentityModule)
+    const [f64Results, f64Err] = await f64.Call(
+      null,
+      'id64',
+      0x400921fb54442d18n,
+    )
+    expect(f64Err).toBeNull()
+    expect(f64Results).toEqual([0x400921fb54442d18n])
+  })
+
+  it('preserves synchronous Go host errors and ExitError identity', async () => {
+    const goErr = $.newError('concrete host failure')!
+    const goErrorInstance = await instantiate(
+      importedIncrementModule,
+      () => goErr,
+    )
+    const [, callErr] = await goErrorInstance.Call(null, 'run')
+    expect(callErr).toBe(goErr)
+    expect(callErr?.Error()).toBe('concrete host failure')
+
+    const exitErr = NewExitError(23)
+    const exitInstance = await instantiate(
+      importedIncrementModule,
+      () => exitErr,
+    )
+    const [, exitCallErr] = await exitInstance.Call(null, 'run')
+    expect(exitCallErr).toBe(exitErr)
+    expect(exitCallErr?.Error()).toBe('exit: 23')
+    expect((exitCallErr as typeof exitErr).ExitCode()).toBe(23)
+  })
+
+  it('rejects Promise-valued host functions', async () => {
+    const instance = await instantiate(
+      importedIncrementModule,
+      async () => null,
+    )
+    const [, callErr] = await instance.Call(null, 'run')
+    expect(callErr?.Error()).toContain('asynchronous WebAssembly host function')
+  })
+
+  it('returns a Go error for a nil module config', async () => {
+    const [module, compileErr] = await New().Compile(
+      null,
+      importedIncrementModule,
+    )
+    expect(compileErr).toBeNull()
+
+    const [instance, instantiateErr] = await module!.Instantiate(null, null)
+    expect(instance).toBeNull()
+    expect(instantiateErr?.Error()).toContain('nil pointer dereference')
+  })
+})

--- a/gs/github.com/aperturerobotics/wasivm/wazero/kernel/runtime/browser/browser.ts
+++ b/gs/github.com/aperturerobotics/wasivm/wazero/kernel/runtime/browser/browser.ts
@@ -1,21 +1,30 @@
 // Package browser_runtime implements VmRuntime backed by the browser
-// WebAssembly API. Pure TypeScript -- no syscall/js indirection.
+// WebAssembly API. Pure TypeScript, without syscall/js indirection.
+
+import * as $ from '@goscript/builtin/index.js'
+import type * as context from '@goscript/context/index.js'
 
 import type * as vmruntime from '../runtime.js'
 
 // Runtime implements VmRuntime using the browser WebAssembly API.
 export class Runtime implements vmruntime.VmRuntime {
-  constructor() {}
-
   // Compile calls WebAssembly.compile and returns a Module.
-  async Compile(_ctx: any, wasm: Uint8Array | number[]): Promise<Module> {
-    const bytes = wasm instanceof Uint8Array ? wasm : new Uint8Array(wasm)
-    const compiled = await WebAssembly.compile(bytes.buffer as ArrayBuffer)
-    return new Module(compiled)
+  async Compile(
+    _ctx: context.Context | null,
+    wasm: $.Slice<number>,
+  ): Promise<[Module | null, $.GoError]> {
+    try {
+      const bytes = new Uint8Array($.asArray(wasm))
+      const functionTypes = readFunctionTypes(bytes)
+      const compiled = await WebAssembly.compile(bytes)
+      return [new Module(compiled, functionTypes), null]
+    } catch (err) {
+      return [null, toGoError(err)]
+    }
   }
 
   // Close is a no-op for the browser runtime.
-  async Close(_ctx: any): Promise<null> {
+  async Close(_ctx: context.Context | null): Promise<$.GoError> {
     return null
   }
 }
@@ -27,38 +36,47 @@ export function New(): Runtime {
 
 // Module wraps a WebAssembly.Module.
 export class Module implements vmruntime.VmModule {
-  constructor(private readonly wasmModule: WebAssembly.Module) {}
+  constructor(
+    private readonly wasmModule: WebAssembly.Module,
+    private readonly functionTypes: ModuleFunctionTypes,
+  ) {}
 
   // Instantiate creates an instance with host functions wired as imports.
   async Instantiate(
-    ctx: any,
-    config: vmruntime.VmModuleConfig,
-  ): Promise<Instance> {
-    const imports = this.buildImports(ctx, config.HostFunctions)
-    const wasmInst = await WebAssembly.instantiate(this.wasmModule, imports)
-    const inst = new Instance(wasmInst)
-    // Patch the captured instance reference in host function closures.
-    if ((imports as any).__instRef) {
-      ;(imports as any).__instRef.current = inst
+    ctx: context.Context | null,
+    config:
+      | vmruntime.VmModuleConfig
+      | $.VarRef<vmruntime.VmModuleConfig>
+      | null,
+  ): Promise<[Instance | null, $.GoError]> {
+    try {
+      const hostFunctions = $.pointerValue(config).HostFunctions
+      const { imports, instRef } = this.buildImports(ctx, hostFunctions)
+      const wasmInst = await WebAssembly.instantiate(this.wasmModule, imports)
+      const inst = new Instance(wasmInst, this.functionTypes.exports)
+      instRef.current = inst
+      return [inst, null]
+    } catch (err) {
+      return [null, toGoError(err)]
     }
-    return inst
   }
 
   // Close is a no-op.
-  async Close(_ctx: any): Promise<null> {
+  async Close(_ctx: context.Context | null): Promise<$.GoError> {
     return null
   }
 
   // buildImports constructs the WebAssembly imports object.
   private buildImports(
-    ctx: any,
-    hostFns: Map<string, vmruntime.HostFunction> | null,
-  ): WebAssembly.Imports {
+    ctx: context.Context | null,
+    hostFns: Map<string, vmruntime.HostFunction | null> | null,
+  ): {
+    imports: WebAssembly.Imports
+    instRef: { current: Instance | null }
+  } {
     const imports: Record<string, Record<string, WebAssembly.ImportValue>> = {}
-    if (!hostFns) return imports
-
-    // Shared mutable ref -- patched after instantiation.
     const instRef: { current: Instance | null } = { current: null }
+    if (!hostFns) return { imports, instRef }
 
     hostFns.forEach((fn, key) => {
       let modName = 'env'
@@ -70,22 +88,42 @@ export class Module implements vmruntime.VmModule {
       }
       if (!imports[modName]) imports[modName] = {}
 
-      imports[modName][funcName] = (...args: number[]) => {
-        const stack = new BigInt64Array(args.length)
-        for (let i = 0; i < args.length; i++) {
-          stack[i] = BigInt(args[i])
-        }
-        const u64Stack: number[] = args.map((a) => a >>> 0)
-        const err = fn(ctx, instRef.current, u64Stack)
-        if (err) throw err
-        // WASM i32 return: first stack element.
-        if (u64Stack.length > 0) return u64Stack[0]
-      }
+      const functionTypes = this.functionTypes.imports.get(
+        `${modName}.${funcName}`,
+      )
+      if (!functionTypes) return
+      let importIndex = 0
+      Object.defineProperty(imports[modName], funcName, {
+        configurable: true,
+        get: () => {
+          const functionType = functionTypes[importIndex++]
+          if (!functionType) {
+            throw $.newError(`unexpected WebAssembly import lookup: ${key}`)
+          }
+          return (...args: Array<number | bigint>) => {
+            if (fn === null) {
+              throw $.newError(`nil host function: ${key}`)
+            }
+            const stack = args.map((arg, index) =>
+              wasmValueToStack(arg, functionType.parameters[index]),
+            )
+            const err = fn(ctx, instRef.current, stack)
+            if (isPromiseLike(err)) {
+              void Promise.resolve(err).catch(() => {})
+              throw $.newError(`asynchronous WebAssembly host function: ${key}`)
+            }
+            if (err) throw err
+            const results = functionType.results.map((type, index) =>
+              stackToWasmValue(stack[index] ?? 0n, type),
+            )
+            if (results.length === 0) return
+            return results.length === 1 ? results[0] : results
+          }
+        },
+      })
     })
 
-    // Stash the ref so Instantiate can patch it.
-    ;(imports as any).__instRef = instRef
-    return imports
+    return { imports, instRef }
   }
 }
 
@@ -93,21 +131,35 @@ export class Module implements vmruntime.VmModule {
 export class Instance implements vmruntime.VmInstance {
   private readonly exports: WebAssembly.Exports
 
-  constructor(private readonly wasmInstance: WebAssembly.Instance) {
+  constructor(
+    private readonly wasmInstance: WebAssembly.Instance,
+    private readonly functionTypes: Map<string, WasmFunctionType>,
+  ) {
     this.exports = wasmInstance.exports
   }
 
   // Call invokes an exported function by name.
   async Call(
-    _ctx: any,
+    _ctx: context.Context | null,
     name: string,
-    ...args: number[]
-  ): Promise<number[] | null> {
+    ...args: bigint[]
+  ): Promise<[$.Slice<bigint>, $.GoError]> {
     const fn = this.exports[name]
-    if (typeof fn !== 'function') return null
-    const result = (fn as (...args: number[]) => unknown)(...args)
-    if (result === undefined) return null
-    return [result as number]
+    if (typeof fn !== 'function') return [null, null]
+    try {
+      const functionType = this.functionTypes.get(name)
+      if (!functionType)
+        return [null, $.newError(`unknown function type: ${name}`)]
+      const wasmArgs = args.map((arg, index) =>
+        stackToWasmValue(arg, functionType.parameters[index]),
+      )
+      const result = (fn as (...args: Array<number | bigint>) => unknown)(
+        ...wasmArgs,
+      )
+      return [wasmResultsToStack(result, functionType.results), null]
+    } catch (err) {
+      return [null, toGoError(err)]
+    }
   }
 
   // Memory returns the instance's linear memory.
@@ -121,30 +173,47 @@ export class Instance implements vmruntime.VmInstance {
   ExportedFunction(name: string): BrowserFunction | null {
     const fn = this.exports[name]
     if (typeof fn !== 'function') return null
-    return new BrowserFunction(fn as (...args: number[]) => unknown)
+    const functionType = this.functionTypes.get(name)
+    if (!functionType) return null
+    return new BrowserFunction(
+      fn as (...args: Array<number | bigint>) => unknown,
+      functionType,
+    )
   }
 
   // ExportedGlobal returns a reference to an exported global.
   ExportedGlobal(name: string): BrowserGlobal | null {
-    const g = this.exports[name]
-    if (!(g instanceof WebAssembly.Global)) return null
-    return new BrowserGlobal(g)
+    const global = this.exports[name]
+    if (!(global instanceof WebAssembly.Global)) return null
+    return new BrowserGlobal(global)
   }
 
   // Close is a no-op.
-  async Close(_ctx: any): Promise<null> {
+  async Close(_ctx: context.Context | null): Promise<$.GoError> {
     return null
   }
 }
 
 // BrowserFunction wraps a WebAssembly exported function.
 export class BrowserFunction implements vmruntime.VmFunction {
-  constructor(private readonly fn: (...args: number[]) => unknown) {}
+  constructor(
+    private readonly fn: (...args: Array<number | bigint>) => unknown,
+    private readonly functionType: WasmFunctionType,
+  ) {}
 
-  async Call(_ctx: any, ...args: number[]): Promise<number[] | null> {
-    const result = this.fn(...args)
-    if (result === undefined) return null
-    return [result as number]
+  async Call(
+    _ctx: context.Context | null,
+    ...args: bigint[]
+  ): Promise<[$.Slice<bigint>, $.GoError]> {
+    try {
+      const wasmArgs = args.map((arg, index) =>
+        stackToWasmValue(arg, this.functionType.parameters[index]),
+      )
+      const result = this.fn(...wasmArgs)
+      return [wasmResultsToStack(result, this.functionType.results), null]
+    } catch (err) {
+      return [null, toGoError(err)]
+    }
   }
 }
 
@@ -152,12 +221,13 @@ export class BrowserFunction implements vmruntime.VmFunction {
 export class BrowserGlobal implements vmruntime.VmGlobal {
   constructor(private readonly global: WebAssembly.Global) {}
 
-  Get(): number {
-    return this.global.value as number
+  Get(): bigint {
+    return BigInt(this.global.value)
   }
 
-  Set(val: number): void {
-    this.global.value = val
+  Set(val: bigint): void {
+    this.global.value =
+      typeof this.global.value === 'bigint' ? val : Number(val)
   }
 }
 
@@ -169,8 +239,8 @@ export class BrowserMemory implements vmruntime.VmMemory {
     return this.mem.buffer
   }
 
-  Read(offset: number, length: number): [Uint8Array, boolean] {
-    if (offset + length > this.buf.byteLength) return [new Uint8Array(0), false]
+  Read(offset: number, length: number): [$.Slice<number>, boolean] {
+    if (offset + length > this.buf.byteLength) return [null, false]
     return [new Uint8Array(this.buf, offset, length), true]
   }
 
@@ -186,14 +256,12 @@ export class BrowserMemory implements vmruntime.VmMemory {
 
   ReadUint64Le(offset: number): [bigint, boolean] {
     if (offset + 8 > this.buf.byteLength) return [0n, false]
-    const dv = new DataView(this.buf)
-    const lo = BigInt(dv.getUint32(offset, true))
-    const hi = BigInt(dv.getUint32(offset + 4, true))
-    return [lo | (hi << 32n), true]
+    return [new DataView(this.buf).getBigUint64(offset, true), true]
   }
 
-  Write(offset: number, data: Uint8Array | number[]): boolean {
-    const bytes = data instanceof Uint8Array ? data : new Uint8Array(data)
+  Write(offset: number, data: $.Slice<number>): boolean {
+    const bytes =
+      data instanceof Uint8Array ? data : new Uint8Array($.asArray(data))
     if (offset + bytes.length > this.buf.byteLength) return false
     new Uint8Array(this.buf, offset, bytes.length).set(bytes)
     return true
@@ -211,12 +279,9 @@ export class BrowserMemory implements vmruntime.VmMemory {
     return true
   }
 
-  WriteUint64Le(offset: number, val: bigint | number): boolean {
+  WriteUint64Le(offset: number, val: bigint): boolean {
     if (offset + 8 > this.buf.byteLength) return false
-    const v = typeof val === 'bigint' ? val : BigInt(val)
-    const dv = new DataView(this.buf)
-    dv.setUint32(offset, Number(v & 0xffffffffn), true)
-    dv.setUint32(offset + 4, Number((v >> 32n) & 0xffffffffn), true)
+    new DataView(this.buf).setBigUint64(offset, val, true)
     return true
   }
 
@@ -226,10 +291,275 @@ export class BrowserMemory implements vmruntime.VmMemory {
 
   Grow(pages: number): [number, boolean] {
     try {
-      const prev = this.mem.grow(pages)
-      return [prev, true]
+      return [this.mem.grow(pages), true]
     } catch {
       return [0, false]
     }
+  }
+}
+
+type WasmValueType =
+  | 'i32'
+  | 'i64'
+  | 'f32'
+  | 'f64'
+  | 'v128'
+  | 'funcref'
+  | 'externref'
+
+type WasmFunctionType = {
+  parameters: WasmValueType[]
+  results: WasmValueType[]
+}
+
+type ModuleFunctionTypes = {
+  imports: Map<string, WasmFunctionType[]>
+  exports: Map<string, WasmFunctionType>
+}
+
+function toGoError(err: unknown): $.GoError {
+  if (
+    (typeof err === 'object' || typeof err === 'function') &&
+    err !== null &&
+    'Error' in err &&
+    typeof err.Error === 'function'
+  ) {
+    return err as $.GoError
+  }
+  return err instanceof Error ? $.toGoError(err) : $.newError(String(err))
+}
+
+function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
+  return (
+    (typeof value === 'object' || typeof value === 'function') &&
+    value !== null &&
+    'then' in value &&
+    typeof value.then === 'function'
+  )
+}
+
+function wasmValueToStack(value: number | bigint, type: WasmValueType): bigint {
+  switch (type) {
+    case 'i32':
+      return BigInt((value as number) >>> 0)
+    case 'i64':
+      return BigInt.asUintN(64, value as bigint)
+    case 'f32': {
+      const view = new DataView(new ArrayBuffer(4))
+      view.setFloat32(0, value as number, true)
+      return BigInt(view.getUint32(0, true))
+    }
+    case 'f64': {
+      const view = new DataView(new ArrayBuffer(8))
+      view.setFloat64(0, value as number, true)
+      return view.getBigUint64(0, true)
+    }
+    default:
+      throw new Error(`unsupported WebAssembly value type: ${type}`)
+  }
+}
+
+function stackToWasmValue(value: bigint, type: WasmValueType): number | bigint {
+  switch (type) {
+    case 'i32':
+      return Number(BigInt.asIntN(32, value))
+    case 'i64':
+      return BigInt.asIntN(64, value)
+    case 'f32': {
+      const view = new DataView(new ArrayBuffer(4))
+      view.setUint32(0, Number(BigInt.asUintN(32, value)), true)
+      return view.getFloat32(0, true)
+    }
+    case 'f64': {
+      const view = new DataView(new ArrayBuffer(8))
+      view.setBigUint64(0, BigInt.asUintN(64, value), true)
+      return view.getFloat64(0, true)
+    }
+    default:
+      throw new Error(`unsupported WebAssembly value type: ${type}`)
+  }
+}
+
+function wasmResultsToStack(
+  result: unknown,
+  resultTypes: WasmValueType[],
+): $.Slice<bigint> {
+  if (resultTypes.length === 0) return null
+  const results = resultTypes.length === 1 ? [result] : (result as unknown[])
+  return results.map((value, index) =>
+    wasmValueToStack(value as number | bigint, resultTypes[index]),
+  )
+}
+
+function readFunctionTypes(bytes: Uint8Array): ModuleFunctionTypes {
+  const reader = new WasmReader(bytes)
+  reader.expect([0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00])
+
+  const types: WasmFunctionType[] = []
+  const importedTypeIndexes: number[] = []
+  const importedNames: string[] = []
+  const definedTypeIndexes: number[] = []
+  const exportedFunctions = new Map<string, number>()
+
+  while (!reader.done) {
+    const sectionID = reader.byte()
+    const section = reader.section()
+    switch (sectionID) {
+      case 1:
+        section.vector(() => {
+          if (section.byte() !== 0x60) throw new Error('invalid function type')
+          types.push({
+            parameters: section.vector(() => section.valueType()),
+            results: section.vector(() => section.valueType()),
+          })
+        })
+        break
+      case 2:
+        section.vector(() => {
+          const moduleName = section.name()
+          const fieldName = section.name()
+          const kind = section.byte()
+          if (kind === 0) {
+            importedTypeIndexes.push(section.uint())
+            importedNames.push(`${moduleName}.${fieldName}`)
+          } else {
+            section.skipImportType(kind)
+          }
+        })
+        break
+      case 3:
+        definedTypeIndexes.push(...section.vector(() => section.uint()))
+        break
+      case 7:
+        section.vector(() => {
+          const name = section.name()
+          const kind = section.byte()
+          const index = section.uint()
+          if (kind === 0) exportedFunctions.set(name, index)
+        })
+        break
+    }
+  }
+
+  const imports = new Map<string, WasmFunctionType[]>()
+  importedNames.forEach((name, index) => {
+    const functionType = types[importedTypeIndexes[index]]
+    const functionTypes = imports.get(name)
+    if (functionTypes) functionTypes.push(functionType)
+    else imports.set(name, [functionType])
+  })
+  const functionTypeIndexes = importedTypeIndexes.concat(definedTypeIndexes)
+  const exports = new Map<string, WasmFunctionType>()
+  exportedFunctions.forEach((index, name) => {
+    exports.set(name, types[functionTypeIndexes[index]])
+  })
+  return { imports, exports }
+}
+
+class WasmReader {
+  private offset = 0
+
+  constructor(private readonly bytes: Uint8Array) {}
+
+  get done(): boolean {
+    return this.offset === this.bytes.length
+  }
+
+  byte(): number {
+    const value = this.bytes[this.offset]
+    if (value === undefined) throw new Error('unexpected end of WebAssembly')
+    this.offset++
+    return value
+  }
+
+  uint(): number {
+    let value = 0
+    let shift = 0
+    while (true) {
+      const byte = this.byte()
+      value += (byte & 0x7f) * 2 ** shift
+      if ((byte & 0x80) === 0) return value
+      shift += 7
+      if (shift > 49) throw new Error('WebAssembly integer is too large')
+    }
+  }
+
+  name(): string {
+    const length = this.uint()
+    const start = this.offset
+    this.offset += length
+    if (this.offset > this.bytes.length) {
+      throw new Error('unexpected end of WebAssembly name')
+    }
+    return new TextDecoder().decode(this.bytes.subarray(start, this.offset))
+  }
+
+  vector<T>(read: () => T): T[] {
+    return Array.from({ length: this.uint() }, read)
+  }
+
+  valueType(): WasmValueType {
+    switch (this.byte()) {
+      case 0x7f:
+        return 'i32'
+      case 0x7e:
+        return 'i64'
+      case 0x7d:
+        return 'f32'
+      case 0x7c:
+        return 'f64'
+      case 0x7b:
+        return 'v128'
+      case 0x70:
+        return 'funcref'
+      case 0x6f:
+        return 'externref'
+      default:
+        throw new Error('invalid WebAssembly value type')
+    }
+  }
+
+  section(): WasmReader {
+    const length = this.uint()
+    const start = this.offset
+    this.offset += length
+    if (this.offset > this.bytes.length) {
+      throw new Error('unexpected end of WebAssembly section')
+    }
+    return new WasmReader(this.bytes.subarray(start, this.offset))
+  }
+
+  expect(expected: number[]): void {
+    for (const byte of expected) {
+      if (this.byte() !== byte) throw new Error('invalid WebAssembly header')
+    }
+  }
+
+  skipImportType(kind: number): void {
+    switch (kind) {
+      case 1:
+        this.byte()
+        this.skipLimits()
+        return
+      case 2:
+        this.skipLimits()
+        return
+      case 3:
+        this.byte()
+        this.byte()
+        return
+      case 4:
+        this.byte()
+        this.uint()
+        return
+      default:
+        throw new Error('invalid WebAssembly import type')
+    }
+  }
+
+  private skipLimits(): void {
+    const flags = this.uint()
+    this.uint()
+    if ((flags & 1) !== 0) this.uint()
   }
 }

--- a/gs/github.com/aperturerobotics/wasivm/wazero/kernel/runtime/runtime.ts
+++ b/gs/github.com/aperturerobotics/wasivm/wazero/kernel/runtime/runtime.ts
@@ -1,65 +1,93 @@
 // Package vmruntime defines abstract interfaces for WASM execution engines.
 
+import type * as $ from '@goscript/builtin/index.js'
+import type * as context from '@goscript/context/index.js'
+
 // VmRuntime abstracts the WASM execution engine.
 export interface VmRuntime {
-  Compile(ctx: any, wasm: Uint8Array | number[]): Promise<VmModule>
-  Close(ctx: any): Promise<any>
+  Compile(
+    ctx: context.Context | null,
+    wasm: $.Slice<number>,
+  ): Promise<[VmModule | null, $.GoError]>
+  Close(ctx: context.Context | null): Promise<$.GoError>
 }
 
 // VmModule represents a compiled WASM module.
 export interface VmModule {
-  Instantiate(ctx: any, config: VmModuleConfig): Promise<VmInstance>
-  Close(ctx: any): Promise<any>
+  Instantiate(
+    ctx: context.Context | null,
+    config: VmModuleConfig | $.VarRef<VmModuleConfig> | null,
+  ): Promise<[VmInstance | null, $.GoError]>
+  Close(ctx: context.Context | null): Promise<$.GoError>
 }
 
 // VmModuleConfig contains configuration for module instantiation.
-export interface VmModuleConfig {
+export class VmModuleConfig {
   Name: string
-  Args: string[] | null
-  Env: string[] | null
+  Args: $.Slice<string>
+  Env: $.Slice<string>
   Stdin: any
   Stdout: any
   Stderr: any
-  HostFunctions: Map<string, HostFunction> | null
+  HostFunctions: Map<string, HostFunction | null> | null
+
+  constructor(init: Partial<VmModuleConfig> = {}) {
+    this.Name = init.Name ?? ''
+    this.Args = init.Args ?? null
+    this.Env = init.Env ?? null
+    this.Stdin = init.Stdin ?? null
+    this.Stdout = init.Stdout ?? null
+    this.Stderr = init.Stderr ?? null
+    this.HostFunctions = init.HostFunctions ?? null
+  }
 }
 
 // HostFunction is a host-provided function callable from WASM.
-export type HostFunction = (
-  ctx: any,
-  inst: VmInstance | null,
-  stack: number[],
-) => any
+export type HostFunction =
+  | ((
+      ctx: context.Context | null,
+      inst: VmInstance | null,
+      stack: $.Slice<bigint>,
+    ) => $.GoError | Promise<$.GoError>)
+  | null
 
 // VmInstance represents a running WASM module instance.
 export interface VmInstance {
-  Call(ctx: any, name: string, ...args: number[]): Promise<number[] | null>
+  Call(
+    ctx: context.Context | null,
+    name: string,
+    ...args: bigint[]
+  ): Promise<[$.Slice<bigint>, $.GoError]>
   Memory(): VmMemory | null
   ExportedFunction(name: string): VmFunction | null
   ExportedGlobal(name: string): VmGlobal | null
-  Close(ctx: any): Promise<any>
+  Close(ctx: context.Context | null): Promise<$.GoError>
 }
 
 // VmFunction represents an exported WASM function.
 export interface VmFunction {
-  Call(ctx: any, ...args: number[]): Promise<number[] | null>
+  Call(
+    ctx: context.Context | null,
+    ...args: bigint[]
+  ): Promise<[$.Slice<bigint>, $.GoError]>
 }
 
 // VmGlobal represents an exported WASM global variable.
 export interface VmGlobal {
-  Get(): number
-  Set(val: number): void
+  Get(): bigint
+  Set(val: bigint): void
 }
 
 // VmMemory abstracts access to WASM linear memory.
 export interface VmMemory {
-  Read(offset: number, length: number): [Uint8Array | number[], boolean]
+  Read(offset: number, length: number): [$.Slice<number>, boolean]
   ReadByteAt(offset: number): [number, boolean]
   ReadUint32Le(offset: number): [number, boolean]
-  ReadUint64Le(offset: number): [bigint | number, boolean]
-  Write(offset: number, data: Uint8Array | number[]): boolean
+  ReadUint64Le(offset: number): [bigint, boolean]
+  Write(offset: number, data: $.Slice<number>): boolean
   WriteByteAt(offset: number, val: number): boolean
   WriteUint32Le(offset: number, val: number): boolean
-  WriteUint64Le(offset: number, val: bigint | number): boolean
+  WriteUint64Le(offset: number, val: bigint): boolean
   Size(): number
   Grow(pages: number): [number, boolean]
 }
@@ -71,6 +99,10 @@ export class ExitError extends Error {
   constructor(code: number) {
     super('exit: ' + code)
     this.Code = code
+  }
+
+  Error(): string {
+    return this.message
   }
 
   ExitCode(): number {
@@ -85,10 +117,10 @@ export function NewExitError(code: number): ExitError {
 
 // Snapshotable is an optional extension for VmInstance.
 export interface Snapshotable {
-  Snapshot(): Snapshot
+  Snapshot(): Snapshot | null
 }
 
 // Snapshot represents a captured execution state.
 export interface Snapshot {
-  Restore(returnValues: number[]): void
+  Restore(returnValues: $.Slice<bigint>): void
 }


### PR DESCRIPTION
The browser runtime uses JavaScript numbers and unstructured return values where generated Go callers require uint64 stack bits and Go-style result and error tuples. This loses i64 precision, obscures host errors, and prevents the WASIVM browser package from satisfying its generated interface.

This aligns the handwritten runtime declarations and browser adapter with the generated GoScript ABI. Stack bits remain bigint values, each imported function signature is decoded independently, host calls stay synchronous, and concrete Go errors preserve ExitError identity. Generated context helper results retain their declared nullable interface type so strict generated package checks agree with Go return types.

Focused coverage exercises integer and floating-point stack representations, duplicate import signatures, host failures, Promise rejection, and nil module configuration. This is the generated contract and ABI prerequisite for WASIVM's browser adapter; it does not complete or claim proc_exit behavior.
